### PR TITLE
Refactor cellular registration to use manual operator selection

### DIFF
--- a/src/airgradientCellularClient.cpp
+++ b/src/airgradientCellularClient.cpp
@@ -55,7 +55,7 @@ bool AirgradientCellularClient::begin(std::string sn, PayloadType pt) {
 
   // Register network
   result =
-      cell_->startNetworkRegistration(CellTechnology::Auto, _apn, _networkRegistrationTimeoutMs);
+      cell_->startNetworkRegistration(CellTechnology::LTE, _apn, _networkRegistrationTimeoutMs);
   if (result.status != CellReturnStatus::Ok) {
     AG_LOGE(TAG, "Cellular client failed, module cannot register to network");
     return false;
@@ -100,7 +100,7 @@ bool AirgradientCellularClient::ensureClientConnection(bool reset) {
 
   // Register network
   auto result =
-      cell_->startNetworkRegistration(CellTechnology::Auto, _apn, _networkRegistrationTimeoutMs);
+      cell_->startNetworkRegistration(CellTechnology::LTE, _apn, _networkRegistrationTimeoutMs);
   if (result.status != CellReturnStatus::Ok) {
     AG_LOGE(TAG, "Cellular client failed, module cannot register to network");
     clientReady = false;

--- a/src/airgradientCellularClient.cpp
+++ b/src/airgradientCellularClient.cpp
@@ -79,7 +79,7 @@ void AirgradientCellularClient::setNetworkRegistrationTimeoutMs(int timeoutMs) {
 std::string AirgradientCellularClient::getICCID() { return _iccid; }
 
 bool AirgradientCellularClient::ensureClientConnection(bool reset) {
-  AG_LOGE(TAG, "Ensuring client connection, restarting cellular module");
+  AG_LOGI(TAG, "Ensuring client connection, restarting cellular module");
   if (reset) {
     if (cell_->reset() == false) {
       AG_LOGW(TAG, "Reset failed, power cycle module...");

--- a/src/cellularModule.cpp
+++ b/src/cellularModule.cpp
@@ -37,7 +37,8 @@ CellReturnStatus CellularModule::isNetworkRegistered(CellTechnology ct) {
 
 CellResult<std::string> CellularModule::startNetworkRegistration(CellTechnology ct,
                                                                  const std::string &apn,
-                                                                 uint32_t operationTimeoutMs) {
+                                                                 uint32_t operationTimeoutMs,
+                                                                 uint32_t scanTimeoutMs) {
   return CellResult<std::string>();
 }
 

--- a/src/cellularModule.cpp
+++ b/src/cellularModule.cpp
@@ -31,6 +31,14 @@ CellResult<int> CellularModule::retrieveSignal() { return CellResult<int>(); }
 
 CellResult<std::string> CellularModule::retrieveIPAddr() { return CellResult<std::string>(); }
 
+bool CellularModule::setOperators(const std::string &serialized, uint32_t operatorId) {
+  return false;
+}
+
+std::string CellularModule::getSerializedOperators() const { return std::string(); }
+
+uint32_t CellularModule::getCurrentOperatorId() const { return 0; }
+
 CellReturnStatus CellularModule::isNetworkRegistered(CellTechnology ct) {
   return CellReturnStatus();
 }

--- a/src/cellularModule.h
+++ b/src/cellularModule.h
@@ -49,6 +49,9 @@ public:
   virtual CellReturnStatus isSimReady();
   virtual CellResult<int> retrieveSignal();
   virtual CellResult<std::string> retrieveIPAddr();
+  virtual bool setOperators(const std::string &serialized, uint32_t operatorId);
+  virtual std::string getSerializedOperators() const;
+  virtual uint32_t getCurrentOperatorId() const;
   virtual CellReturnStatus isNetworkRegistered(CellTechnology ct);
   virtual CellResult<std::string> startNetworkRegistration(CellTechnology ct,
                                                            const std::string &apn,

--- a/src/cellularModule.h
+++ b/src/cellularModule.h
@@ -52,7 +52,8 @@ public:
   virtual CellReturnStatus isNetworkRegistered(CellTechnology ct);
   virtual CellResult<std::string> startNetworkRegistration(CellTechnology ct,
                                                            const std::string &apn,
-                                                           uint32_t operationTimeoutMs = 90000);
+                                                           uint32_t operationTimeoutMs = 90000,
+                                                           uint32_t scanTimeoutMs = 600000);
   virtual CellReturnStatus reinitialize();
   virtual CellResult<HttpResponse> httpGet(const std::string &url, int connectionTimeout = -1,
                                            int responseTimeout = -1);

--- a/src/cellularModuleA7672xx.cpp
+++ b/src/cellularModuleA7672xx.cpp
@@ -269,7 +269,8 @@ CellReturnStatus CellularModuleA7672XX::isNetworkRegistered(CellTechnology ct) {
 
 CellResult<std::string>
 CellularModuleA7672XX::startNetworkRegistration(CellTechnology ct, const std::string &apn,
-                                                uint32_t operationTimeoutMs) {
+                                                uint32_t operationTimeoutMs,
+                                                uint32_t scanTimeoutMs) {
   CellResult<std::string> result;
   result.status = CellReturnStatus::Timeout;
 
@@ -279,84 +280,74 @@ CellularModuleA7672XX::startNetworkRegistration(CellTechnology ct, const std::st
     return result;
   }
 
-  // start time for whole operation
+  // Time tracking
   uint32_t startOperationTime = MILLIS();
-  // start time for certain state (check network registration and check ensure service ready)
-  uint32_t startStateTime = MILLIS();
+  uint32_t autoModeStartTime = 0;        // Track time in auto mode (2 min timeout)
+  uint32_t manualOperatorStartTime = 0;  // Track time per operator in manual mode (30 sec timeout)
 
   NetworkRegistrationState state = CHECK_MODULE_READY;
   bool finish = false;
 
-  AG_LOGI(TAG, "Start operation network registration");
+  AG_LOGI(TAG, "Starting network registration (operation timeout: %" PRIu32 " ms, scan timeout: %" PRIu32 " ms)",
+          operationTimeoutMs, scanTimeoutMs);
+
   while ((MILLIS() - startOperationTime) < operationTimeoutMs && !finish) {
     switch (state) {
     case CHECK_MODULE_READY: {
       state = _implCheckModuleReady();
       if (state == CHECK_MODULE_READY) {
-        // No point to retry check if module ready or not
-        // It needs to restarted / power cycled / make sure sim card attached
-        ESP_LOGE(TAG, "CE card is not ready");
+        // Module or SIM not ready - cannot proceed
+        AG_LOGE(TAG, "Module or SIM card is not ready");
         finish = true;
         continue;
       }
       break;
     }
-    case PREPARE_REGISTRATION:
-      state = _implPrepareRegistration(ct);
-      startStateTime = MILLIS();
+
+    case PREPARE_MODULE:
+      state = _implPrepareModule(ct, apn);
       break;
+
+    case SCAN_OPERATOR:
+      state = _implScanOperator(scanTimeoutMs);
+      break;
+
+    case CONFIGURE_AUTO_NETWORK:
+      state = _implConfigureAutoNetwork();
+      // Reset auto mode timer when entering auto mode
+      autoModeStartTime = MILLIS();
+      break;
+
+    case CONFIGURE_MANUAL_NETWORK:
+      state = _implConfigureManualNetwork();
+      // Reset manual operator timer when selecting new operator
+      manualOperatorStartTime = MILLIS();
+      break;
+
     case CHECK_NETWORK_REGISTRATION:
-      if ((MILLIS() - startStateTime) > 15000) {
-        // Timeout wait network registration to expected status, configuring network
-        state = CONFIGURE_NETWORK;
-        continue;
-      }
-      state = _implCheckNetworkRegistration(ct);
-      // If registration status as expected, continue to ENSURE_SERVICE_READY
-      if (state == ENSURE_SERVICE_READY) {
-        // Reset time for ENSURE_SERVICE_READY
-        startStateTime = MILLIS();
-      }
+      state = _implCheckNetworkRegistration(ct, autoModeStartTime, manualOperatorStartTime);
       break;
-    case ENSURE_SERVICE_READY:
-      if ((MILLIS() - startStateTime) > 10000) {
-        // Timeout wait service ready, configuring service
-        state = CONFIGURE_SERVICE;
-        continue;
-      }
-      state = _implEnsureServiceReady();
+
+    case CHECK_SERVICE_STATUS:
+      state = _implCheckServiceStatus(apn);
       break;
-    case CONFIGURE_NETWORK:
-      // Here's after finish goes back to check network registration status
-      state = _implConfigureNetwork(apn);
-      // After configuring network, check network registration status
-      // Reset time for CHECK_NETWORK_REGISTRATION
-      startStateTime = MILLIS();
-      break;
-    case CONFIGURE_SERVICE:
-      // Here's after finish goes back to check network registration status
-      state = _implConfigureService(apn);
-      // After configuring service, make sure service is now ready
-      // Reset time for ENSURE_SERVICE_READY
-      startStateTime = MILLIS();
-      break;
-    case NETWORK_REGISTERED:
-      state = _implNetworkRegistered();
-      if (state == NETWORK_REGISTERED) {
-        // Still the same state, indicating process finish successfully
+
+    case NETWORK_READY:
+      state = _implNetworkReady();
+      if (state == NETWORK_READY) {
+        // Network registration complete!
         finish = true;
         continue;
       }
-      // Reset time because it might go back to ENSURE_SERVICE_READY
-      startStateTime = MILLIS();
       break;
     }
+
     // Give CPU a break
     DELAY_MS(1);
   }
 
-  if (state != NETWORK_REGISTERED) {
-    AG_LOGW(TAG, "Register to network operation failed!");
+  if (state != NETWORK_READY) {
+    AG_LOGW(TAG, "Network registration failed! Final state: %d", state);
     return result;
   }
 
@@ -824,184 +815,304 @@ CellReturnStatus CellularModuleA7672XX::mqttPublish(const std::string &topic,
 }
 
 CellularModuleA7672XX::NetworkRegistrationState CellularModuleA7672XX::_implCheckModuleReady() {
+  // Check if module responds to AT commands
   if (at_->testAT() == false) {
     REGIS_RETRY_DELAY();
     // TODO: If too long, try reset module
     return CHECK_MODULE_READY;
   }
+
+  // Check if SIM card is ready
   if (isSimReady() != CellReturnStatus::Ok) {
     REGIS_RETRY_DELAY();
     return CHECK_MODULE_READY;
   }
 
-  AG_LOGI(TAG, "Continue: PREPARE_REGISTRATION");
-  return PREPARE_REGISTRATION;
+  // Detect if module is already prepared by checking current operator mode
+  CellResult<std::string> modeResult = _detectCurrentOperatorMode();
+
+  if (modeResult.status == CellReturnStatus::Ok) {
+    // Module is prepared and has operator configuration
+    if (modeResult.data == "auto") {
+      AG_LOGI(TAG, "Module already prepared in automatic mode, continue to: CONFIGURE_AUTO_NETWORK");
+      isManualMode_ = false;
+      return CONFIGURE_AUTO_NETWORK;
+    } else if (modeResult.data != "unknown") {
+      AG_LOGI(TAG, "Module already prepared in manual mode, continue to: CONFIGURE_MANUAL_NETWORK");
+      isManualMode_ = true;
+      // If we don't have operator list yet, we need to scan first
+      if (availableOperators_.empty()) {
+        AG_LOGI(TAG, "No operator list available, need to scan first");
+        return PREPARE_MODULE;
+      }
+      return CONFIGURE_MANUAL_NETWORK;
+    }
+  }
+
+  // Module not prepared or detection failed, prepare from scratch
+  AG_LOGI(TAG, "Module not prepared, continue to: PREPARE_MODULE");
+  return PREPARE_MODULE;
 }
 
 CellularModuleA7672XX::NetworkRegistrationState
-CellularModuleA7672XX::_implPrepareRegistration(CellTechnology ct) {
-  // TODO: Check result
-  _disableNetworkRegistrationURC(ct);
-  _applyCellularTechnology(ct);
-  AG_LOGI(TAG, "Continue: CHECK_NETWORK_REGISTRATION");
-  return CHECK_NETWORK_REGISTRATION;
-}
+CellularModuleA7672XX::_implCheckNetworkRegistration(CellTechnology ct, uint32_t autoModeStartTime,
+                                                      uint32_t manualOperatorStartTime) {
+  // Get detailed registration status
+  CellResult<RegistrationStatus> statusResult = _checkDetailedRegistrationStatus(ct);
 
-CellularModuleA7672XX::NetworkRegistrationState
-CellularModuleA7672XX::_implCheckNetworkRegistration(CellTechnology ct) {
-  CellReturnStatus crs;
-  if (ct == CellTechnology::Auto) {
-    crs = _checkAllRegistrationStatusCommand();
+  if (statusResult.status == CellReturnStatus::Timeout) {
+    AG_LOGW(TAG, "Timeout checking registration status");
+    return CHECK_MODULE_READY;
+  }
+
+  if (statusResult.status != CellReturnStatus::Ok) {
+    REGIS_RETRY_DELAY();
+    return CHECK_NETWORK_REGISTRATION;
+  }
+
+  int stat = statusResult.data.stat;
+
+  // Always query signal strength for logging
+  CellResult<int> signalResult = retrieveSignal();
+  int signal = (signalResult.status == CellReturnStatus::Ok) ? signalResult.data : 99;
+
+  // Always query operator attachment for logging
+  CellResult<std::string> copsResult = _detectCurrentOperatorMode();
+  std::string copsInfo = (copsResult.status == CellReturnStatus::Ok) ? copsResult.data : "unknown";
+
+  // Log all three values together for debugging
+  AG_LOGI(TAG, "Registration check - Status: %d, Signal: %d, COPS: %s", stat, signal, copsInfo.c_str());
+
+  // Check for registered states (1 = home, 5 = roaming)
+  if (stat == 1 || stat == 5) {
+    // Registered! Validate signal before proceeding
+    if (signalResult.status == CellReturnStatus::Timeout) {
+      return CHECK_MODULE_READY;
+    }
+
+    // Check if returned signal is valid
+    if (signal < 1 || signal > 31) {
+      AG_LOGW(TAG, "Invalid signal: %d", signal);
+      REGIS_RETRY_DELAY();
+      return CHECK_NETWORK_REGISTRATION;
+    }
+
+    AG_LOGI(TAG, "Registered successfully, continue to: CHECK_SERVICE_STATUS");
+    return CHECK_SERVICE_STATUS;
+  }
+
+  // Not registered - handle based on mode and status code
+  if (!isManualMode_) {
+    // AUTO MODE
+    // Check for denied (3) or emergency bearer only (11)
+    if (stat == 3 || stat == 11) {
+      AG_LOGW(TAG, "Registration denied or restricted (status=%d)", stat);
+      // Switch to manual mode if we've been trying auto for 2 minutes
+      if ((MILLIS() - autoModeStartTime) > 120000) {
+        AG_LOGI(TAG, "Auto mode failed after 2 minutes, switching to manual mode");
+        return CONFIGURE_MANUAL_NETWORK;
+      }
+    } else if ((MILLIS() - autoModeStartTime) > 120000) {
+      // Not registered after 2 minutes in auto mode
+      AG_LOGW(TAG, "Not registered after 2 minutes in auto mode, switching to manual");
+      return CONFIGURE_MANUAL_NETWORK;
+    }
+
+    // Still trying in auto mode
+    REGIS_RETRY_DELAY();
+    return CHECK_NETWORK_REGISTRATION;
   } else {
-    crs = isNetworkRegistered(ct);
-  }
+    // MANUAL MODE
+    // Check if we've been trying this operator for 30 seconds
+    if ((MILLIS() - manualOperatorStartTime) > 30000) {
+      AG_LOGW(TAG, "Not registered with current operator after 30 seconds, trying next");
+      currentOperatorIndex_++;
+      return CONFIGURE_MANUAL_NETWORK;
+    }
 
-  if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
-    return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Failed || crs == CellReturnStatus::Error) {
+    // Still trying current operator
     REGIS_RETRY_DELAY();
     return CHECK_NETWORK_REGISTRATION;
   }
-
-  CellResult<int> result = retrieveSignal();
-  if (result.status == CellReturnStatus::Timeout) {
-    // Go back to check module ready
-    return CHECK_MODULE_READY;
-  }
-  // Check if returned signal is valid
-  if (result.data < 1 || result.data > 31) {
-    REGIS_RETRY_DELAY();
-    return CHECK_NETWORK_REGISTRATION;
-  }
-
-  AG_LOGI(TAG, "Continue: ENSURE_SERVICE_READY");
-  return ENSURE_SERVICE_READY;
 }
 
-CellularModuleA7672XX::NetworkRegistrationState CellularModuleA7672XX::_implEnsureServiceReady() {
-  CellReturnStatus crs = _isServiceAvailable();
+// New state machine implementations
+
+CellularModuleA7672XX::NetworkRegistrationState
+CellularModuleA7672XX::_implPrepareModule(CellTechnology ct, const std::string &apn) {
+  AG_LOGI(TAG, "Preparing module for registration");
+
+  // Disable network registration URC
+  CellReturnStatus crs = _disableNetworkRegistrationURC(ct);
   if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
     return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Failed || crs == CellReturnStatus::Error) {
-    REGIS_RETRY_DELAY();
-    return ENSURE_SERVICE_READY;
   }
 
-  // Check if network attach
-  crs = _ensurePacketDomainAttached(false);
-  if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
+  // Apply cellular technology
+  crs = _applyCellularTechnology(ct);
+  if (crs != CellReturnStatus::Ok) {
+    AG_LOGW(TAG, "Failed to apply cellular technology");
     return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Failed || crs == CellReturnStatus::Error) {
-    REGIS_RETRY_DELAY();
-    return ENSURE_SERVICE_READY;
   }
 
-  AG_LOGI(TAG, "Continue: NETWORK_REGISTERED");
-  return NETWORK_REGISTERED;
+  // Apply APN
+  crs = _applyAPN(apn);
+  if (crs == CellReturnStatus::Timeout) {
+    return CHECK_MODULE_READY;
+  }
+
+  AG_LOGI(TAG, "Module prepared, continue to: SCAN_OPERATOR");
+  return SCAN_OPERATOR;
 }
 
 CellularModuleA7672XX::NetworkRegistrationState
-CellularModuleA7672XX::_implConfigureNetwork(const std::string &apn) {
-  CellResult<int> result = retrieveSignal();
-  if (result.status == CellReturnStatus::Timeout) {
-    // Go back to check module ready
+CellularModuleA7672XX::_implScanOperator(uint32_t scanTimeoutMs) {
+  AG_LOGI(TAG, "Scanning for available operators");
+
+  CellResult<std::vector<OperatorInfo>> scanResult = _scanAvailableOperators(scanTimeoutMs);
+
+  if (scanResult.status == CellReturnStatus::Timeout) {
+    AG_LOGW(TAG, "Operator scan timed out");
+    return CHECK_MODULE_READY;
+  } else if (scanResult.status != CellReturnStatus::Ok || scanResult.data.empty()) {
+    AG_LOGW(TAG, "Operator scan failed or returned no operators");
     return CHECK_MODULE_READY;
   }
 
-  AG_LOGI(TAG, "Cellular signal: %d", result.data);
+  // Store operator list
+  availableOperators_ = scanResult.data;
+  currentOperatorIndex_ = 0;
 
-  CellReturnStatus crs = _applyAPN(apn);
+  AG_LOGI(TAG, "Operator scan complete, continue to: CONFIGURE_AUTO_NETWORK");
+  return CONFIGURE_AUTO_NETWORK;
+}
+
+CellularModuleA7672XX::NetworkRegistrationState CellularModuleA7672XX::_implConfigureAutoNetwork() {
+  AG_LOGI(TAG, "Configuring automatic operator selection");
+
+  // Set preferred bands
+  CellReturnStatus crs = _applyPreferedBands();
   if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
     return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Error) {
-    // TODO: What's next if this return error?
   }
 
-  crs = _checkOperatorSelection();
-  if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
-    return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Ok) {
-    // Result already as expected, go back to check network registration status
-    return CHECK_NETWORK_REGISTRATION;
-  }
-
-  _printNetworkInfo();
-
-  crs = _applyPreferedBands();
-  if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
-    return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Error) {
-    // TODO: What's next if this return error?
-  }
-
-  AG_LOGI(TAG, "Wait band settings to be applied for 5s, before set COPS back to automatic");
+  // Wait for band settings to be applied
+  AG_LOGI(TAG, "Waiting for band settings to be applied (5s)");
   DELAY_MS(5000);
 
-  crs = _applyOperatorSelection();
+  // Set automatic operator selection
+  crs = _applyOperatorSelection(0, -1);  // operatorId=0 means automatic
   if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
     return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Error) {
-    // TODO: What's next if this return error?
+  } else if (crs != CellReturnStatus::Ok) {
+    AG_LOGW(TAG, "Failed to set automatic operator selection");
+    return CHECK_MODULE_READY;
   }
 
-  AG_LOGI(TAG, "Continue: CHECK_NETWORK_REGISTRATION");
+  isManualMode_ = false;
+  AG_LOGI(TAG, "Automatic mode configured, continue to: CHECK_NETWORK_REGISTRATION");
   return CHECK_NETWORK_REGISTRATION;
 }
 
 CellularModuleA7672XX::NetworkRegistrationState
-CellularModuleA7672XX::_implConfigureService(const std::string &apn) {
-  CellReturnStatus crs = _activatePDPContext();
-  if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
-    return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Error) {
-    // TODO: What's next if this return error?
+CellularModuleA7672XX::_implConfigureManualNetwork() {
+  // Check if we have operators to try
+  if (availableOperators_.empty() || currentOperatorIndex_ >= availableOperators_.size()) {
+    AG_LOGW(TAG, "No more operators to try in manual mode, falling back to automatic");
+    currentOperatorIndex_ = 0;
+    return CONFIGURE_AUTO_NETWORK;
   }
 
-  crs = _ensurePacketDomainAttached(true);
+  OperatorInfo opInfo = availableOperators_[currentOperatorIndex_];
+  AG_LOGI(TAG, "Configuring manual operator: %" PRIu32 " with AcT: %d (index %zu of %zu)",
+          opInfo.operatorId, opInfo.accessTech, currentOperatorIndex_ + 1, availableOperators_.size());
+
+  CellReturnStatus crs = _applyOperatorSelection(opInfo.operatorId, opInfo.accessTech);
   if (crs == CellReturnStatus::Timeout) {
-    // Go back to check module ready
     return CHECK_MODULE_READY;
-  } else if (crs == CellReturnStatus::Error) {
-    // TODO: What's next if this return error?
+  } else if (crs != CellReturnStatus::Ok) {
+    AG_LOGW(TAG, "Failed to select operator %" PRIu32 ", trying next", opInfo.operatorId);
+    currentOperatorIndex_++;
+    return CONFIGURE_MANUAL_NETWORK;
   }
 
-  AG_LOGI(TAG, "Continue: CHECK_NETWORK_REGISTRATION");
+  isManualMode_ = true;
+  AG_LOGI(TAG, "Manual operator configured, continue to: CHECK_NETWORK_REGISTRATION");
   return CHECK_NETWORK_REGISTRATION;
 }
 
-CellularModuleA7672XX::NetworkRegistrationState CellularModuleA7672XX::_implNetworkRegistered() {
-  CellResult<int> result = retrieveSignal();
-  if (result.status == CellReturnStatus::Timeout) {
-    // Go back to check module ready
+CellularModuleA7672XX::NetworkRegistrationState
+CellularModuleA7672XX::_implCheckServiceStatus(const std::string &apn) {
+  AG_LOGI(TAG, "Checking service status");
+
+  // Check if service is available
+  CellReturnStatus crs = _isServiceAvailable();
+  if (crs == CellReturnStatus::Timeout) {
+    return CHECK_MODULE_READY;
+  } else if (crs == CellReturnStatus::Failed || crs == CellReturnStatus::Error) {
+    REGIS_RETRY_DELAY();
+    return CHECK_SERVICE_STATUS;
+  }
+
+  // Activate PDP context
+  crs = _activatePDPContext();
+  if (crs == CellReturnStatus::Timeout) {
+    return CHECK_MODULE_READY;
+  } else if (crs == CellReturnStatus::Error) {
+    AG_LOGW(TAG, "Failed to activate PDP context");
+    REGIS_RETRY_DELAY();
+    return CHECK_SERVICE_STATUS;
+  }
+
+  // Ensure packet domain is attached
+  crs = _ensurePacketDomainAttached(true);
+  if (crs == CellReturnStatus::Timeout) {
+    return CHECK_MODULE_READY;
+  } else if (crs == CellReturnStatus::Failed || crs == CellReturnStatus::Error) {
+    REGIS_RETRY_DELAY();
+    return CHECK_SERVICE_STATUS;
+  }
+
+  AG_LOGI(TAG, "Service ready, continue to: NETWORK_READY");
+  return NETWORK_READY;
+}
+
+CellularModuleA7672XX::NetworkRegistrationState CellularModuleA7672XX::_implNetworkReady() {
+  AG_LOGI(TAG, "Verifying network is ready");
+
+  // Check signal quality
+  CellResult<int> signalResult = retrieveSignal();
+  if (signalResult.status == CellReturnStatus::Timeout) {
     return CHECK_MODULE_READY;
   }
 
   // Check if returned signal is valid
-  if (result.data < 1 || result.data > 31) {
+  if (signalResult.data < 1 || signalResult.data > 31) {
+    AG_LOGW(TAG, "Invalid signal strength: %d", signalResult.data);
     REGIS_RETRY_DELAY();
-    return ENSURE_SERVICE_READY;
+    return CHECK_SERVICE_STATUS;
   }
 
-  // print signal
-  AG_LOGI(TAG, "Signal ready at: %d", result.data);
+  AG_LOGI(TAG, "Signal ready at: %d", signalResult.data);
 
-  CellResult<std::string> resultIP = retrieveIPAddr();
-  if (resultIP.data.empty()) {
-    // Sanity check if IP is empty, go back ensure service ready
-    return ENSURE_SERVICE_READY;
+  // Retrieve IP address
+  CellResult<std::string> ipResult = retrieveIPAddr();
+  if (ipResult.data.empty()) {
+    AG_LOGW(TAG, "Failed to retrieve IP address");
+    return CHECK_SERVICE_STATUS;
   }
 
-  AG_LOGI(TAG, "IP Addr: %s", resultIP.data.c_str());
-  AG_LOGI(TAG, "Continue: finish");
-  return NETWORK_REGISTERED;
+  AG_LOGI(TAG, "IP Addr: %s", ipResult.data.c_str());
+
+  // If in manual mode and successfully connected, log the operator
+  if (isManualMode_ && currentOperatorIndex_ < availableOperators_.size()) {
+    OperatorInfo opInfo = availableOperators_[currentOperatorIndex_];
+    AG_LOGI(TAG, "Successfully registered with manual operator: %" PRIu32 " (AcT: %d)",
+            opInfo.operatorId, opInfo.accessTech);
+  }
+
+  AG_LOGI(TAG, "Network registration complete!");
+  return NETWORK_READY;
 }
 
 CellReturnStatus CellularModuleA7672XX::_disableNetworkRegistrationURC(CellTechnology ct) {
@@ -1084,10 +1195,27 @@ CellReturnStatus CellularModuleA7672XX::_applyPreferedBands() {
   return CellReturnStatus::Ok;
 }
 
-CellReturnStatus CellularModuleA7672XX::_applyOperatorSelection() {
-  at_->sendAT("+COPS=0,2");
+CellReturnStatus CellularModuleA7672XX::_applyOperatorSelection(uint32_t operatorId, int accessTech) {
+  char buf[50] = {0};
+
+  if (operatorId == 0) {
+    // Automatic operator selection
+    AG_LOGI(TAG, "Setting operator selection to automatic mode");
+    at_->sendAT("+COPS=0,2");
+  } else {
+    // Manual operator selection with operator ID and access technology
+    if (accessTech >= 0) {
+      AG_LOGI(TAG, "Setting operator: %" PRIu32 " with AcT: %d", operatorId, accessTech);
+      sprintf(buf, "+COPS=1,2,\"%" PRIu32 "\",%d", operatorId, accessTech);
+    } else {
+      AG_LOGI(TAG, "Setting operator: %" PRIu32 " (no AcT specified)", operatorId);
+      sprintf(buf, "+COPS=1,2,\"%" PRIu32 "\"", operatorId);
+    }
+    at_->sendAT(buf);
+  }
+
   if (at_->waitResponse() != ATCommandHandler::ExpArg1) {
-    // TODO: This should be error or timeout
+    AG_LOGW(TAG, "Failed to apply operator selection");
     return CellReturnStatus::Error;
   }
 
@@ -1206,6 +1334,255 @@ CellReturnStatus CellularModuleA7672XX::_activatePDPContext() {
   }
 
   return CellReturnStatus::Ok;
+}
+
+CellResult<std::vector<CellularModuleA7672XX::OperatorInfo>>
+CellularModuleA7672XX::_scanAvailableOperators(uint32_t timeoutMs) {
+  CellResult<std::vector<OperatorInfo>> result;
+  result.status = CellReturnStatus::Timeout;
+
+  AG_LOGI(TAG, "Scanning available operators (this may take up to 10 minutes)...");
+  at_->sendAT("+COPS=?");
+
+  // Wait for response with long timeout (operator scan can take many minutes)
+  if (at_->waitResponse(timeoutMs, "+COPS:") != ATCommandHandler::ExpArg1) {
+    AG_LOGW(TAG, "Timeout or error scanning operators");
+    return result;
+  }
+
+  // Retrieve the full operator list response
+  std::string operatorListRaw;
+  if (at_->waitAndRecvRespLine(operatorListRaw, 2000) == -1) {
+    AG_LOGW(TAG, "Failed to retrieve operator list");
+    return result;
+  }
+
+  // Wait for OK
+  at_->waitResponse();
+
+  AG_LOGD(TAG, "Operator scan response: %s", operatorListRaw.c_str());
+
+  // Parse operator list: (status,"long","short","numeric",tech),(status,...),...
+  // We want to extract "numeric" IDs and tech where status is 1 (available) or 2 (current)
+  std::vector<OperatorInfo> operators;
+  size_t pos = 0;
+
+  while (pos < operatorListRaw.length()) {
+    // Find opening parenthesis
+    size_t openParen = operatorListRaw.find('(', pos);
+    if (openParen == std::string::npos) {
+      break;
+    }
+
+    // Find closing parenthesis
+    size_t closeParen = operatorListRaw.find(')', openParen);
+    if (closeParen == std::string::npos) {
+      break;
+    }
+
+    // Extract the operator entry
+    std::string entry = operatorListRaw.substr(openParen + 1, closeParen - openParen - 1);
+
+    // Parse: status,"long","short","numeric",tech
+    // Split by comma, but be careful with quoted strings
+    std::vector<std::string> parts;
+    bool inQuotes = false;
+    std::string currentPart;
+
+    for (size_t i = 0; i < entry.length(); i++) {
+      char c = entry[i];
+      if (c == '"') {
+        inQuotes = !inQuotes;
+      } else if (c == ',' && !inQuotes) {
+        parts.push_back(currentPart);
+        currentPart.clear();
+      } else {
+        currentPart += c;
+      }
+    }
+    if (!currentPart.empty()) {
+      parts.push_back(currentPart);
+    }
+
+    // Validate we have enough parts and extract numeric ID and access tech
+    if (parts.size() >= 5) {
+      // Parse status manually using atoi (no exceptions)
+      int status = atoi(parts[0].c_str());
+
+      // Only include available (1) or current (2) operators
+      if (status == 1 || status == 2) {
+        // Parse operator ID and access tech as integers
+        uint32_t operatorId = (uint32_t)atoi(parts[3].c_str());
+        int accessTech = atoi(parts[4].c_str());
+
+        if (operatorId > 0) {
+          OperatorInfo opInfo;
+          opInfo.operatorId = operatorId;
+          opInfo.accessTech = accessTech;
+          operators.push_back(opInfo);
+          AG_LOGI(TAG, "Found operator: %" PRIu32 " with AcT: %d (status=%d)",
+                  operatorId, accessTech, status);
+        }
+      }
+    }
+
+    pos = closeParen + 1;
+  }
+
+  if (operators.empty()) {
+    AG_LOGW(TAG, "No available operators found in scan");
+    result.status = CellReturnStatus::Failed;
+    return result;
+  }
+
+  AG_LOGI(TAG, "Found %zu available operator(s)", operators.size());
+  result.status = CellReturnStatus::Ok;
+  result.data = operators;
+  return result;
+}
+
+CellResult<CellularModuleA7672XX::RegistrationStatus>
+CellularModuleA7672XX::_parseRegistrationStatus(const std::string &response) {
+  CellResult<RegistrationStatus> result;
+  result.status = CellReturnStatus::Failed;
+
+  // Expected format: "0,1" or "1,5" or "0,3" etc.
+  // Format: <n>,<stat>[,<lac>,<ci>,<AcT>]
+
+  // Split by comma to get mode and stat
+  size_t firstComma = response.find(',');
+  if (firstComma == std::string::npos) {
+    AG_LOGW(TAG, "Invalid registration status format: %s", response.c_str());
+    return result;
+  }
+
+  // Parse mode manually using atoi (no exceptions)
+  std::string modeStr = response.substr(0, firstComma);
+  result.data.mode = atoi(modeStr.c_str());
+
+  // Find second comma (if exists) to isolate stat value
+  size_t secondComma = response.find(',', firstComma + 1);
+  std::string statStr;
+  if (secondComma != std::string::npos) {
+    statStr = response.substr(firstComma + 1, secondComma - firstComma - 1);
+  } else {
+    statStr = response.substr(firstComma + 1);
+  }
+
+  // Parse stat manually using atoi (no exceptions)
+  result.data.stat = atoi(statStr.c_str());
+
+  // Basic validation (mode should be 0, 1, or 2)
+  if (result.data.mode < 0 || result.data.mode > 2) {
+    AG_LOGE(TAG, "Invalid registration mode: %d", result.data.mode);
+    result.status = CellReturnStatus::Error;
+    return result;
+  }
+
+  result.status = CellReturnStatus::Ok;
+  AG_LOGD(TAG, "Parsed registration status: mode=%d, stat=%d", result.data.mode, result.data.stat);
+
+  return result;
+}
+
+CellResult<CellularModuleA7672XX::RegistrationStatus>
+CellularModuleA7672XX::_checkDetailedRegistrationStatus(CellTechnology ct) {
+  CellResult<RegistrationStatus> result;
+  result.status = CellReturnStatus::Timeout;
+
+  auto cmdNR = _mapCellTechToNetworkRegisCmd(ct);
+  if (cmdNR.empty()) {
+    result.status = CellReturnStatus::Error;
+    return result;
+  }
+
+  char buf[15] = {0};
+  sprintf(buf, "+%s?", cmdNR.c_str());
+  at_->sendAT(buf);
+
+  int resp = at_->waitResponse("+CREG:", "+CEREG:", "+CGREG:");
+  if (resp != ATCommandHandler::ExpArg1 && resp != ATCommandHandler::ExpArg2 &&
+      resp != ATCommandHandler::ExpArg3) {
+    AG_LOGW(TAG, "Timeout waiting for registration status response");
+    return result;
+  }
+
+  std::string recv;
+  if (at_->waitAndRecvRespLine(recv) == -1) {
+    AG_LOGW(TAG, "Failed to receive registration status line");
+    return result;
+  }
+
+  // Wait for OK
+  at_->waitResponse();
+
+  // Parse the response
+  return _parseRegistrationStatus(recv);
+}
+
+CellResult<std::string> CellularModuleA7672XX::_detectCurrentOperatorMode() {
+  CellResult<std::string> result;
+  result.status = CellReturnStatus::Timeout;
+
+  at_->sendAT("+COPS?");
+  if (at_->waitResponse("+COPS:") != ATCommandHandler::ExpArg1) {
+    AG_LOGW(TAG, "Timeout querying current operator mode");
+    return result;
+  }
+
+  std::string response;
+  if (at_->waitAndRecvRespLine(response) == -1) {
+    AG_LOGW(TAG, "Failed to receive COPS? response");
+    return result;
+  }
+
+  // Wait for OK
+  at_->waitResponse();
+
+  // Parse response: <mode>,<format>,"<oper>"[,<AcT>]
+  // mode: 0=automatic, 1=manual, 4=manual/automatic
+  size_t firstComma = response.find(',');
+  if (firstComma == std::string::npos) {
+    AG_LOGW(TAG, "Invalid COPS? response format: %s", response.c_str());
+    result.status = CellReturnStatus::Failed;
+    return result;
+  }
+
+  // Parse mode manually using atoi (no exceptions)
+  std::string modeStr = response.substr(0, firstComma);
+  int mode = atoi(modeStr.c_str());
+
+  // Validate mode value (0=auto, 1=manual, 2=deregister, 3=set format only, 4=manual/auto)
+  if (mode < 0 || mode > 4) {
+    AG_LOGW(TAG, "Invalid COPS mode: %d", mode);
+    result.status = CellReturnStatus::Failed;
+    return result;
+  }
+
+  if (mode == 0) {
+    result.data = "auto";
+    AG_LOGI(TAG, "Current operator mode: automatic");
+  } else if (mode == 1 || mode == 4) {
+    // Extract operator ID from response
+    // Format after mode: <format>,"<oper>"
+    size_t firstQuote = response.find('"', firstComma);
+    size_t secondQuote = response.find('"', firstQuote + 1);
+
+    if (firstQuote != std::string::npos && secondQuote != std::string::npos) {
+      result.data = response.substr(firstQuote + 1, secondQuote - firstQuote - 1);
+      AG_LOGI(TAG, "Current operator mode: manual, operator=%s", result.data.c_str());
+    } else {
+      result.data = "manual";
+      AG_LOGI(TAG, "Current operator mode: manual (operator ID not parsed)");
+    }
+  } else {
+    result.data = "unknown";
+    AG_LOGW(TAG, "Unknown operator mode: %d", mode);
+  }
+
+  result.status = CellReturnStatus::Ok;
+
+  return result;
 }
 
 CellReturnStatus CellularModuleA7672XX::_httpInit() {

--- a/src/cellularModuleA7672xx.cpp
+++ b/src/cellularModuleA7672xx.cpp
@@ -342,10 +342,22 @@ CellularModuleA7672XX::startNetworkRegistration(CellTechnology ct, const std::st
         continue;
       }
 
-      // Haven't reached max attempts yet, reset index and try again
+      // Reset module to ensure the next registration attempt in clean state
+      // In case every operator return 3 or 11
+      if (reset() == false) {
+        AG_LOGW(TAG, "Reset failed, power cycle module...");
+        powerOff(true);
+        DELAY_MS(2000);
+        powerOn();
+      }
+      AG_LOGI(TAG, "Wait for 10s for module to warming up");
+      DELAY_MS(10000);
+      reinitialize();
+
+      // Haven't reached max attempts yet, reset index start over
       AG_LOGI(TAG, "Resetting operator index to retry from beginning");
       currentOperatorIndex_ = 0;
-      state = CONFIGURE_MANUAL_NETWORK;  // Continue with retry
+      state = CHECK_MODULE_READY;
       break;
     }
 

--- a/src/cellularModuleA7672xx.cpp
+++ b/src/cellularModuleA7672xx.cpp
@@ -1045,9 +1045,11 @@ CellularModuleA7672XX::_implConfigureManualNetwork() {
   OperatorInfo opInfo = availableOperators_[currentOperatorIndex_];
   AG_LOGI(TAG, "Configuring manual operator: %" PRIu32 " with AcT: %d (index %zu of %zu)",
           opInfo.operatorId, opInfo.accessTech, currentOperatorIndex_ + 1, availableOperators_.size());
+  DELAY_MS(5000);
 
   CellReturnStatus crs = _applyOperatorSelection(opInfo.operatorId, opInfo.accessTech);
   if (crs == CellReturnStatus::Timeout) {
+    currentOperatorIndex_++;
     return CHECK_MODULE_READY;
   } else if (crs != CellReturnStatus::Ok) {
     AG_LOGW(TAG, "Failed to select operator %" PRIu32 ", trying next", opInfo.operatorId);
@@ -1231,7 +1233,7 @@ CellReturnStatus CellularModuleA7672XX::_applyOperatorSelection(uint32_t operato
     AG_LOGW(TAG, "Timeout to apply operator selection");
     return CellReturnStatus::Timeout;
   }
-  else if (result != ATCommandHandler::ExpArg2) {
+  else if (result == ATCommandHandler::ExpArg2) {
     AG_LOGW(TAG, "Error to apply operator selection");
     return CellReturnStatus::Error;
   }

--- a/src/cellularModuleA7672xx.cpp
+++ b/src/cellularModuleA7672xx.cpp
@@ -920,6 +920,14 @@ CellularModuleA7672XX::_implCheckNetworkRegistration(CellTechnology ct,
       AG_LOGW(TAG, "Invalid signal: %d", signal);
       REGIS_RETRY_DELAY();
       return CHECK_NETWORK_REGISTRATION;
+    } else if (signal < 10) {
+      AG_LOGW(TAG,
+              "This operator %" PRIu32 " has really low signal %d (csq), moving on..",
+              currentOperatorId_, signal);
+      currentOperatorId_ = 0; // Clear saved operator
+      currentOperatorIndex_++;
+      REGIS_RETRY_DELAY();
+      return CONFIGURE_MANUAL_NETWORK;
     }
 
     AG_LOGI(TAG, "Registered successfully, continue to: CHECK_SERVICE_STATUS");

--- a/src/cellularModuleA7672xx.h
+++ b/src/cellularModuleA7672xx.h
@@ -54,8 +54,7 @@ private:
   // Operator selection for manual network registration
   std::vector<OperatorInfo> availableOperators_;  // Persisted operator list with IDs and access tech
   size_t currentOperatorIndex_ = 0;               // Track position in manual mode
-  uint32_t currentOperatorId_ = 0;                // Current operator PLMN ID
-  bool isManualMode_ = false;                     // Track if currently in manual operator selection mode
+  uint32_t currentOperatorId_ = 0;                // Current operator PLMN ID (saved successful operator)
 
 public:
   // Structure to hold detailed registration status
@@ -65,14 +64,12 @@ public:
   };
 
   enum NetworkRegistrationState {
-    // Check if AT ready, Check if SIM ready, Detect if module already prepared
+    // Check if AT ready, Check if SIM ready
     CHECK_MODULE_READY,
     // Disable network registration URC, Set cellular technology, Set APN
     PREPARE_MODULE,
     // Scan available operators (AT+COPS=?) and populate operator list
     SCAN_OPERATOR,
-    // Configure automatic operator selection (AT+COPS=0,2)
-    CONFIGURE_AUTO_NETWORK,
     // Configure manual operator selection by iterating through scanned operator list
     CONFIGURE_MANUAL_NETWORK,
     // Check network registration status (CREG/CEREG/CGREG) and signal quality
@@ -129,9 +126,8 @@ private:
   NetworkRegistrationState _implCheckModuleReady();
   NetworkRegistrationState _implPrepareModule(CellTechnology ct, const std::string &apn);
   NetworkRegistrationState _implScanOperator(uint32_t scanTimeoutMs);
-  NetworkRegistrationState _implConfigureAutoNetwork();
   NetworkRegistrationState _implConfigureManualNetwork();
-  NetworkRegistrationState _implCheckNetworkRegistration(CellTechnology ct, uint32_t autoModeStartTime,
+  NetworkRegistrationState _implCheckNetworkRegistration(CellTechnology ct,
                                                           uint32_t manualOperatorStartTime);
   NetworkRegistrationState _implCheckServiceStatus(const std::string &apn);
   NetworkRegistrationState _implNetworkReady();
@@ -140,8 +136,7 @@ private:
   CellReturnStatus _disableNetworkRegistrationURC(CellTechnology ct); // depend on CellTech
   CellReturnStatus _checkAllRegistrationStatusCommand();
   CellReturnStatus _applyCellularTechnology(CellTechnology ct);
-  CellReturnStatus _applyPreferedBands();
-  CellReturnStatus _applyOperatorSelection(uint32_t operatorId = 0, int accessTech = -1); // operatorId=0 means auto mode
+  CellReturnStatus _applyOperatorSelection(uint32_t operatorId, int accessTech = -1);
   CellReturnStatus _checkOperatorSelection();
   CellReturnStatus _printNetworkInfo();
   CellReturnStatus _isServiceAvailable();

--- a/src/cellularModuleA7672xx.h
+++ b/src/cellularModuleA7672xx.h
@@ -72,6 +72,8 @@ public:
     SCAN_OPERATOR,
     // Configure manual operator selection by iterating through scanned operator list
     CONFIGURE_MANUAL_NETWORK,
+    // All operators in list have been tried without success
+    OPERATOR_LIST_EXHAUSTED,
     // Check network registration status (CREG/CEREG/CGREG) and signal quality
     CHECK_NETWORK_REGISTRATION,
     // Ensure service available (CNSMOD), Activate PDP context, Check packet domain attached
@@ -138,7 +140,6 @@ private:
   CellReturnStatus _applyCellularTechnology(CellTechnology ct);
   CellReturnStatus _applyOperatorSelection(uint32_t operatorId, int accessTech = -1);
   CellReturnStatus _checkOperatorSelection();
-  CellReturnStatus _printNetworkInfo();
   CellReturnStatus _isServiceAvailable();
   CellReturnStatus _applyAPN(const std::string &apn);
   CellReturnStatus _ensurePacketDomainAttached(bool forceAttach);

--- a/src/cellularModuleA7672xx.h
+++ b/src/cellularModuleA7672xx.h
@@ -131,7 +131,7 @@ private:
   NetworkRegistrationState _implConfigureManualNetwork();
   NetworkRegistrationState _implCheckNetworkRegistration(CellTechnology ct,
                                                           uint32_t manualOperatorStartTime);
-  NetworkRegistrationState _implCheckServiceStatus(const std::string &apn);
+  NetworkRegistrationState _implCheckServiceStatus();
   NetworkRegistrationState _implNetworkReady();
 
   // AT Command functions

--- a/src/cellularModuleA7672xx.h
+++ b/src/cellularModuleA7672xx.h
@@ -11,6 +11,7 @@
 #ifndef ESP8266
 
 #include <string>
+#include <vector>
 
 #include "driver/gpio.h"
 
@@ -44,28 +45,41 @@ private:
   gpio_num_t _powerIO = GPIO_NUM_NC;
   ATCommandHandler *at_ = nullptr;
 
+  // Structure to hold operator information for manual selection
+  struct OperatorInfo {
+    uint32_t operatorId;  // Numeric MCC+MNC (e.g., 46001)
+    int accessTech;       // Access technology: 0=GSM, 2=UTRAN, 7=E-UTRAN(LTE)
+  };
+
+  // Operator selection for manual network registration
+  std::vector<OperatorInfo> availableOperators_;  // Persisted operator list with IDs and access tech
+  size_t currentOperatorIndex_ = 0;               // Track position in manual mode
+  bool isManualMode_ = false;                     // Track if currently in manual operator selection mode
+
 public:
+  // Structure to hold detailed registration status
+  struct RegistrationStatus {
+    int mode;  // URC reporting mode (0 or 1)
+    int stat;  // registration status (0=not searching, 1=registered home, 2=searching, 3=denied, 5=registered roaming, 11=searching/trying)
+  };
+
   enum NetworkRegistrationState {
-    // Check if AT ready
-    // Chec if SIM ready
+    // Check if AT ready, Check if SIM ready, Detect if module already prepared
     CHECK_MODULE_READY,
-    // Disable network registration URC
-    // set cell technology
-    PREPARE_REGISTRATION,
-    // Check network registration status
-    // ensure signal
+    // Disable network registration URC, Set cellular technology, Set APN
+    PREPARE_MODULE,
+    // Scan available operators (AT+COPS=?) and populate operator list
+    SCAN_OPERATOR,
+    // Configure automatic operator selection (AT+COPS=0,2)
+    CONFIGURE_AUTO_NETWORK,
+    // Configure manual operator selection by iterating through scanned operator list
+    CONFIGURE_MANUAL_NETWORK,
+    // Check network registration status (CREG/CEREG/CGREG) and signal quality
     CHECK_NETWORK_REGISTRATION,
-    // Make sure service available CNSMOD
-    ENSURE_SERVICE_READY,
-    // cops select
-    CONFIGURE_NETWORK,
-    // Set APN
-    // Activate PDP context
-    // Make sure packet domain active
-    CONFIGURE_SERVICE,
-    // Print IP address,
-    // final check signal
-    NETWORK_REGISTERED
+    // Ensure service available (CNSMOD), Activate PDP context, Check packet domain attached
+    CHECK_SERVICE_STATUS,
+    // Final checks: signal quality, IP address retrieval
+    NETWORK_READY
   };
 
   CellularModuleA7672XX(AirgradientSerial *agSerial, uint32_t warmUpTimeMs = 0);
@@ -84,7 +98,8 @@ public:
   CellResult<std::string> retrieveIPAddr();
   CellReturnStatus isNetworkRegistered(CellTechnology ct);
   CellResult<std::string> startNetworkRegistration(CellTechnology ct, const std::string &apn,
-                                                   uint32_t operationTimeoutMs = 90000);
+                                                   uint32_t operationTimeoutMs = 90000,
+                                                   uint32_t scanTimeoutMs = 600000);
   CellReturnStatus reinitialize();
   CellResult<CellularModule::HttpResponse>
   httpGet(const std::string &url, int connectionTimeout = -1, int responseTimeout = -1);
@@ -106,25 +121,33 @@ private:
 
   // Network Registration implementation for each state
   NetworkRegistrationState _implCheckModuleReady();
-  NetworkRegistrationState _implPrepareRegistration(CellTechnology ct);
-  NetworkRegistrationState _implCheckNetworkRegistration(CellTechnology ct);
-  NetworkRegistrationState _implEnsureServiceReady();
-  NetworkRegistrationState _implConfigureNetwork(const std::string &apn);
-  NetworkRegistrationState _implConfigureService(const std::string &apn);
-  NetworkRegistrationState _implNetworkRegistered();
+  NetworkRegistrationState _implPrepareModule(CellTechnology ct, const std::string &apn);
+  NetworkRegistrationState _implScanOperator(uint32_t scanTimeoutMs);
+  NetworkRegistrationState _implConfigureAutoNetwork();
+  NetworkRegistrationState _implConfigureManualNetwork();
+  NetworkRegistrationState _implCheckNetworkRegistration(CellTechnology ct, uint32_t autoModeStartTime,
+                                                          uint32_t manualOperatorStartTime);
+  NetworkRegistrationState _implCheckServiceStatus(const std::string &apn);
+  NetworkRegistrationState _implNetworkReady();
 
   // AT Command functions
   CellReturnStatus _disableNetworkRegistrationURC(CellTechnology ct); // depend on CellTech
   CellReturnStatus _checkAllRegistrationStatusCommand();
   CellReturnStatus _applyCellularTechnology(CellTechnology ct);
   CellReturnStatus _applyPreferedBands();
-  CellReturnStatus _applyOperatorSelection();
+  CellReturnStatus _applyOperatorSelection(uint32_t operatorId = 0, int accessTech = -1); // operatorId=0 means auto mode
   CellReturnStatus _checkOperatorSelection();
   CellReturnStatus _printNetworkInfo();
   CellReturnStatus _isServiceAvailable();
   CellReturnStatus _applyAPN(const std::string &apn);
   CellReturnStatus _ensurePacketDomainAttached(bool forceAttach);
   CellReturnStatus _activatePDPContext();
+
+  // Operator scanning and registration status parsing
+  CellResult<std::vector<OperatorInfo>> _scanAvailableOperators(uint32_t timeoutMs);
+  CellResult<RegistrationStatus> _parseRegistrationStatus(const std::string &response);
+  CellResult<RegistrationStatus> _checkDetailedRegistrationStatus(CellTechnology ct);
+  CellResult<std::string> _detectCurrentOperatorMode();
   CellReturnStatus _httpInit();
   CellReturnStatus _httpSetParamTimeout(int connectionTimeout, int responseTimeout);
   CellReturnStatus _httpSetUrl(const std::string &url);

--- a/src/cellularModuleA7672xx.h
+++ b/src/cellularModuleA7672xx.h
@@ -54,6 +54,7 @@ private:
   // Operator selection for manual network registration
   std::vector<OperatorInfo> availableOperators_;  // Persisted operator list with IDs and access tech
   size_t currentOperatorIndex_ = 0;               // Track position in manual mode
+  uint32_t currentOperatorId_ = 0;                // Current operator PLMN ID
   bool isManualMode_ = false;                     // Track if currently in manual operator selection mode
 
 public:
@@ -113,6 +114,11 @@ public:
   CellReturnStatus mqttDisconnect();
   CellReturnStatus mqttPublish(const std::string &topic, const std::string &payload, int qos = 1,
                                int retain = 0, int timeoutS = 15);
+
+  // Operator serialization/deserialization
+  bool setOperators(const std::string &serialized, uint32_t operatorId);
+  std::string getSerializedOperators() const;
+  uint32_t getCurrentOperatorId() const;
 
 private:
   const int DEFAULT_HTTP_CONNECT_TIMEOUT = 120; // seconds


### PR DESCRIPTION
## Summary
- Refactored network registration flow from automatic to manual operator selection
- Implemented operator scanning and intelligent retry mechanism
- Added CSQ (signal quality) validation with minimum threshold of 10
- Enhanced timeout handling and error recovery

## Changes
- **Operator Selection**: Switched from automatic (`COPS=0`) to manual operator selection with scanning
- **Retry Logic**: Added maximum 3 iterations through operator list with module reset between exhaustions
- **Signal Quality**: Reject operators with CSQ < 10, fast-fail on registration denied (stat 3/11)
- **Timeouts**: 60s per operator attempt, 30s for service status check, 600s default scan timeout
- **State Machine**: Refactored registration states for clearer flow (CHECK_MODULE_READY → PREPARE_MODULE →
SCAN_OPERATOR → CONFIGURE_MANUAL_NETWORK → CHECK_NETWORK_REGISTRATION → CHECK_SERVICE_STATUS → NETWORK_READY)
- **Persistence**: Save successful operator ID for faster subsequent connections
- **Technology**: Changed from `Auto` to `LTE` mode